### PR TITLE
Fix fontWeight of MAX button in TokenAmountInput

### DIFF
--- a/components/TokenAmountInput/TokenAmountInput.tsx
+++ b/components/TokenAmountInput/TokenAmountInput.tsx
@@ -109,7 +109,9 @@ const TokenAmountInput: React.FC<TokenAmountInputProps> = ({
         >
           <Button size="xs" onClick={onClickMax} variant={maxButtonVariant}>
             {/* Exact `mt` set to vertically center text ignoring descenders */}
-            <Text mt="3px">MAX</Text>
+            <Text fontWeight={600} mt="3px">
+              MAX
+            </Text>
           </Button>
         </InputRightElement>
       )}


### PR DESCRIPTION
Caused by https://github.com/Rari-Capital/rari-components/commit/42c304cf855d7123b473cf2695b1f87cae09d1f8

# Before

<img width="179" alt="Screen Shot 2022-04-05 at 21 59 31" src="https://user-images.githubusercontent.com/10874225/161899099-796dc52c-49f0-4832-9ab7-ead9298607a1.png">

# After

<img width="198" alt="Screen Shot 2022-04-05 at 21 59 40" src="https://user-images.githubusercontent.com/10874225/161899110-6e8d9f2d-cc61-4fde-b97f-2fa44e3daa95.png">

